### PR TITLE
Add chestplate enchantment check

### DIFF
--- a/src/main/java/xyz/mrmelon54/ArmoredElytra/mixin/MixinLivingEntityChildren.java
+++ b/src/main/java/xyz/mrmelon54/ArmoredElytra/mixin/MixinLivingEntityChildren.java
@@ -30,8 +30,10 @@ public abstract class MixinLivingEntityChildren extends LivingEntity {
                 if (armoredElytraItem != null && armoredElytraItem.getDisplayChestplateTick()) {
                     ItemStack chestplateItemStack = armoredElytraItem.getChestplateItemStack();
                     if (chestplateItemStack != null) {
-                        if (armoredElytraItem.hasEnchantmentGlint())
-                            chestplateItemStack.addEnchantment(Enchantments.MENDING, 1);
+                        if (armoredElytraItem.hasEnchantmentGlint()) {
+                            if (chestplateItemStack.getEnchantments().size() <= 0)
+                                chestplateItemStack.addEnchantment(Enchantments.MENDING, 1);
+                        }
                         callbackInfoReturnable.setReturnValue(chestplateItemStack);
                         callbackInfoReturnable.cancel();
                     }


### PR DESCRIPTION
This makes sure that the chestplate stack's "ghost" enchantment, that enables chestplate glint, isn't added if the chestplate is already enchanted (or if the "ghost" enchantment has already been applied).

Potentially not the best way to correct this bug, but I've tested it in 1.18.2 and can confirm that it works. Mending is only applied to the chestplate stack once, or not at all if the chestplate already has enchantments. Trying to interact with the elytra/chestplate will no longer kick/crash the player.

Fixes #11 