### PR TITLE
Migrate mappings to 1.19.3 and update dependencies to latest/recommended

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.12-SNAPSHOT'
+    id 'fabric-loom' version '1.1-SNAPSHOT'
     id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
@@ -34,7 +34,7 @@ dependencies {
     modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}") {
         transitive = false
     }
-    modImplementation("curse.maven:advanced-netherite-fabric-547881:3820759") {
+    modImplementation("curse.maven:advanced-netherite-fabric-547881:4153697") {
         transitive = false
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-# check these on https://fabricmc.net/use
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.7
+# check these on https://fabricmc.net/develop/
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.17
 # Mod Properties
 mod_version=4.0.0
 maven_group=xyz.mrmelon54
 archives_base_name=armored-elytra
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.55.3+1.19
-modmenu_version=4.0.0
+fabric_version=0.75.1+1.19.3
+modmenu_version=5.0.0

--- a/src/main/java/xyz/mrmelon54/ArmoredElytra/mixin/MixinArmorFeatureRenderer.java
+++ b/src/main/java/xyz/mrmelon54/ArmoredElytra/mixin/MixinArmorFeatureRenderer.java
@@ -29,20 +29,20 @@ public abstract class MixinArmorFeatureRenderer<T extends LivingEntity, M extend
     public abstract void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l);
 
     @Shadow
-    protected abstract A getArmor(EquipmentSlot slot);
+    protected abstract A getModel(EquipmentSlot slot);
 
     @Shadow
     protected abstract void setVisible(A bipedModel, EquipmentSlot slot);
 
     @Shadow
-    protected abstract boolean usesSecondLayer(EquipmentSlot slot);
+    protected abstract boolean usesInnerModel(EquipmentSlot slot);
 
     @Shadow
     protected abstract void renderArmorParts(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, ArmorItem item, boolean usesSecondLayer, A model, boolean legs, float red, float green, float blue, @Nullable String overlay);
 
     @Inject(at = @At("HEAD"), method = "render*")
     public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo info) {
-        renderChestplateForArmouredElytra(matrixStack, vertexConsumerProvider, livingEntity, i, this.getArmor(EquipmentSlot.CHEST));
+        renderChestplateForArmouredElytra(matrixStack, vertexConsumerProvider, livingEntity, i, this.getModel(EquipmentSlot.CHEST));
     }
 
     private void renderChestplateForArmouredElytra(MatrixStack matrices, VertexConsumerProvider vertexConsumers, T entity, int light, A model) {
@@ -51,9 +51,9 @@ public abstract class MixinArmorFeatureRenderer<T extends LivingEntity, M extend
             if (armoredElytra != null) {
                 ItemStack chestplateItemStack = armoredElytra.getChestplateItemStack();
                 if (chestplateItemStack.getItem() instanceof ArmorItem armorItem) {
-                    this.getContextModel().setAttributes(model);
+                    this.getContextModel().copyBipedStateTo(model);
                     this.setVisible(model, EquipmentSlot.CHEST);
-                    boolean bl = this.usesSecondLayer(EquipmentSlot.CHEST);
+                    boolean bl = this.usesInnerModel(EquipmentSlot.CHEST);
                     boolean bl2 = armoredElytra.hasEnchantmentGlint();
                     int i = armoredElytra.getLeatherChestplateColor();
                     if (i != -1) {

--- a/src/main/java/xyz/mrmelon54/ArmoredElytra/models/ArmoredElytraModelProvider.java
+++ b/src/main/java/xyz/mrmelon54/ArmoredElytra/models/ArmoredElytraModelProvider.java
@@ -1,14 +1,15 @@
 package xyz.mrmelon54.ArmoredElytra.models;
 
-import net.minecraft.client.item.UnclampedModelPredicateProvider;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.client.item.ClampedModelPredicateProvider;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import xyz.mrmelon54.ArmoredElytra.ChestplateWithElytraItem;
 import xyz.mrmelon54.ArmoredElytra.InternalArrays;
-import org.jetbrains.annotations.Nullable;
 
-public class ArmoredElytraModelProvider implements UnclampedModelPredicateProvider {
+public class ArmoredElytraModelProvider implements ClampedModelPredicateProvider {
     @Override
     public float unclampedCall(ItemStack stack, @Nullable ClientWorld world, @Nullable LivingEntity entity, int seed) {
         if (stack != null && !stack.isEmpty()) {


### PR DESCRIPTION
Updated the mod to work for 1.19.3, as well as dependencies. Feel free to change any of them to maintain some extra backwards compatibility.

For some reason I was not able to run either the original or modified versions of the mod in my dev environment (separate issue for me to track down I guess). The produced remapped jar seems to work fine in production, although it has not been tested with Advanced Netherite at the time of writing this.

Full list of my changes:

## build.gradle
**Fabric loom**
0.12-SNAPSHOT -> 1.1-SNAPSHOT ([recommended on the Fabric website](https://fabricmc.net/develop/))
**Advanced Netherite [Fabric]**
[[1.19.x] 1.6.0](https://www.curseforge.com/minecraft/mc-mods/advanced-netherite-fabric/files/3820759) -> [[1.19.3] 1.6.6](https://www.curseforge.com/minecraft/mc-mods/advanced-netherite-fabric/files/4153697) (latest for 1.19.3)

## gradle.properties
**Minecraft**
1.19 -> 1.19.3 (Self-explanatory)
**Yarn mappings**
1.19+build.1 -> 1.19.3+build.5 (1.19.3 support, also latest)
**Fabric loader**
0.14.7 -> 0.14.17 (latest)
**Fabric API**
0.55.3+1.19 -> 0.75.1+1.19.3 (latest)
**Mod menu**
4.0.0 -> 5.0.0 (1.19.3 support)

## MixinArmorFeatureRenderer
getArmor() -> getModel()
usesSecondLayer() -> usesInnerModel()
setAttributes() -> copyBipedStateTo()

## ArmoredElytraModelProvider
UnclampedModelPredicateProvider -> ClampedModelPredicateProvider